### PR TITLE
Parse dates in format YYYY-MM-DD from before 1970

### DIFF
--- a/lib/Mojo/XMLRPC.pm
+++ b/lib/Mojo/XMLRPC.pm
@@ -180,7 +180,16 @@ sub _decode_element {
     my $date = Mojo::Date->new($elem->text);
     unless ($date->epoch) {
       require Time::Piece;
-      $date->epoch(Time::Piece->strptime($elem->text, '%Y%m%dT%H:%M:%S')->epoch);
+      my $text = $elem->text;
+      PARSE: for my $time_format ('%H:%M:%S', '%H%M%S') {
+        for my $calendar_format ('%Y%m%d', '%Y-%m-%d') {
+          my $format = $calendar_format . 'T' . $time_format;
+          eval {
+            $date->epoch(Time::Piece->strptime($text, $format)->epoch);
+          };
+          last PARSE unless $@;
+        }
+      }
     }
     return $date;
   } elsif ($tag eq 'base64') {

--- a/t/from_xmlrpc.t
+++ b/t/from_xmlrpc.t
@@ -140,6 +140,25 @@ $msg = from_xmlrpc(<<'MESSAGE');
 <methodResponse>
    <params>
       <param>
+         <value><dateTime.iso8601>1969-12-31T235959</dateTime.iso8601></value>
+         </param>
+      </params>
+   </methodResponse>
+MESSAGE
+
+{
+  isa_ok $msg, 'Mojo::XMLRPC::Message::Response', 'correct message type';
+  ok !$msg->is_fault, 'not a fault';
+  my $date = $msg->parameters->[0];
+  isa_ok $date, 'Mojo::Date', 'got a Mojo::Date';
+  is $date->epoch, -1, 'got the correct date';
+}
+
+$msg = from_xmlrpc(<<'MESSAGE');
+<?xml version="1.0"?>
+<methodResponse>
+   <params>
+      <param>
          <value><base64>eW91IGNhbid0IHJlYWQgdGhpcyE=</base64></value>
          </param>
       </params>


### PR DESCRIPTION
I get dates like 1950-01-02T10:11:12 from an XML-RPC server. Mojo::XMLRPC currently only passes the format '%Y%m%dT%H:%M:%S' without dashes to Time::Piece->strptime and throws an exception.
With the attached patch dates and times from before 1970 in the formats YYYY-MM-DD, YYYYMMDD, HH:MM:SS and HHMMSS are parsed.