### PR TITLE
Handled larger int by <i8> tag + Updated documentation with additional details

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -7,12 +7,25 @@ Mojo::XMLRPC - An XMLRPC message parser/encoder using the Mojo stack
 =head1 SYNOPSIS
 
   use Mojo::UserAgent;
-  use Mojo::XMLRPC qw[to_xmlrpc from_xmlrpc];
+  use Mojo::XMLRPC qw[encode_xmlrpc decode_xmlrpc];
 
   my $ua = Mojo::UserAgent->new;
   my $url = ...;
-  my $tx = $ua->post($url, encode_xmlrpc(call => 'mymethod', 'myarg'));
-  my $res = decode_xmlrpc($tx->res->body)
+  my $tx = $ua->post($url, {'Content-Type' => 'text/xml'}, encode_xmlrpc(call => 'mymethod', 'myarg'));
+  my $res = decode_xmlrpc($tx->res->body);
+
+Or using Content Generators L<Mojo::UserAgent::Transactor#add_generator> which are used to generate the same type of content repeatedly for multiple requests.
+
+  my $ua = Mojo::UserAgent->new;
+  $ua->transactor->add_generator(
+    xmlrpc => sub {
+      my ($transactor, $tx, @args) = @_;
+      $tx->req->headers->content_type('text/xml');
+      $tx->req->body(encode_xmlrpc(call => @args));
+    }
+  );
+  my $tx = $ua->post($url, xmlrpc => $method, @{$params});
+  my $res = decode_xmlrpc($tx->res->body);
 
 =head1 DESCRIPTION
 

--- a/lib/Mojo/XMLRPC.pm
+++ b/lib/Mojo/XMLRPC.pm
@@ -161,7 +161,7 @@ sub _decode_element {
       @{ $elem->children('member') }  # pairs
     };
 
-  } elsif ($tag eq 'int' || $tag eq 'i4') {
+  } elsif ($tag eq 'int' || $tag eq 'i4' || $tag eq 'i8') {
     return $elem->text + 0;
 
   } elsif ($tag eq 'string' || $tag eq 'name') {

--- a/t/from_xmlrpc.t
+++ b/t/from_xmlrpc.t
@@ -252,5 +252,26 @@ is_deeply $msg->fault, {
   faultString => 'Too many parameters.',
 }, 'correct parameters';
 
+$msg = from_xmlrpc(<<'MESSAGE');
+<?xml version="1.0"?>
+<methodResponse>
+   <params>
+      <param>
+        <value>
+            <array>
+               <data>
+               <value><i8>1336542467</i8></value>
+               </data>
+            </array>
+         </value>
+      </param>
+   </params>
+</methodResponse>
+MESSAGE
+
+isa_ok $msg, 'Mojo::XMLRPC::Message::Response', 'correct message type';
+ok !$msg->is_fault, 'not a fault';
+is_deeply $msg->parameters, [[1336542467]], 'correct parameters';
+
 done_testing;
 


### PR DESCRIPTION
1. Added the <i8> tag to handle big integers as reported https://github.com/jberger/Mojo-XMLRPC/issues/4

2. While going through documentation on metacpan, it made me feel it can be improved.

Also I found https://mojolicious.io/blog/2017/12/11/day-11-useragent-content-generators/ which is a good explanation (all thanks to you again). 
So, updated the pod with the more documentation.