### PR TITLE
Provided support for non standard tags + Updated pod

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -111,6 +111,28 @@ Values encoded as integers will not be truncated via C<int> however no attempt i
 Values encoded as floating point C<double> will be forcably upgraded to C<NOK> (by dividing by 1.0).
 This is so that an integer value encoded as a floating point will round trip, the reverse case isn't as useful and thus isn't handled.
 
+Non-Standard tags are also handled while converting to Perl.
+
+=over
+
+=item *
+
+C<i1>, C<i2>, C<i8> will be converted to C<int>
+
+=item *
+
+C<biginteger> will be converted to C<Math::BigInt> using C<bignum>
+
+=item *
+
+C<bigdecimal> will be converted to C<Math::BigFloat> using C<bignum>
+
+=item *
+
+C<float> will be handled like C<double>
+
+=back
+
 =head1 FUNCTIONS
 
 =head2 decode_xmlrpc

--- a/t/from_xmlrpc.t
+++ b/t/from_xmlrpc.t
@@ -252,5 +252,75 @@ is_deeply $msg->fault, {
   faultString => 'Too many parameters.',
 }, 'correct parameters';
 
+$msg = from_xmlrpc(<<'MESSAGE');
+<?xml version="1.0"?>
+<methodResponse>
+   <params>
+      <param>
+        <value>
+          <array>
+            <data>
+              <value><i1>1</i1></value>
+              <value><i2>31</i2></value>
+              <value><i8>1336542467</i8></value>
+            </data>
+          </array>
+        </value>
+      </param>
+    </params>
+  </methodResponse>
+MESSAGE
+
+isa_ok $msg, 'Mojo::XMLRPC::Message::Response', 'correct message type';
+ok !$msg->is_fault, 'not a fault';
+is_deeply $msg->parameters, [[1, 31, 1336542467]], 'correct parameters';
+
+
+$msg = from_xmlrpc(<<'MESSAGE');
+<?xml version="1.0"?>
+<methodResponse>
+   <params>
+      <param>
+        <value>
+            <array>
+               <data>
+                 <value>
+                   <bigdecimal>50924950789635128309.6432068295145406106</bigdecimal>
+                 </value>
+               </data>
+            </array>
+         </value>
+      </param>
+   </params>
+</methodResponse>
+MESSAGE
+
+isa_ok $msg, 'Mojo::XMLRPC::Message::Response', 'correct message type';
+ok !$msg->is_fault, 'not a fault';
+is_deeply $msg->parameters, [[50924950789635128309.6432068295145406106]], 'correct parameters';
+
+$msg = from_xmlrpc(<<'MESSAGE');
+<?xml version="1.0"?>
+<methodResponse>
+   <params>
+      <param>
+        <value>
+            <array>
+               <data>
+                 <value>
+                   <biginteger>2432902008176640000</biginteger>
+                 </value>
+               </data>
+            </array>
+         </value>
+      </param>
+   </params>
+</methodResponse>
+MESSAGE
+
+isa_ok $msg, 'Mojo::XMLRPC::Message::Response', 'correct message type';
+ok !$msg->is_fault, 'not a fault';
+is_deeply $msg->parameters, [[2432902008176640000]], 'correct parameters';
+
 done_testing;
 


### PR DESCRIPTION
Provided non standard tag support. 
* i1, i2, i8
* biginteger
* bigdecimal
* float

I have taken the above list from [Python Client](https://docs.python.org/3/library/xmlrpc.client.html) and tried to provide only those tags for now.

Also, I have created the whole things as dispatch table based (standard as well as non-standard).